### PR TITLE
Update miniflux repository URL

### DIFF
--- a/files/Caddyfile
+++ b/files/Caddyfile
@@ -7,7 +7,7 @@ errors stderr
 root /www/public
 status 403 /data
 git {
-	repo https://github.com/miniflux/miniflux.git
+	repo https://github.com/miniflux/miniflux-legacy.git
 	path ../miniflux-src
 	interval 86400
 	then /bin/sh /www/miniflux-install.sh


### PR DESCRIPTION
The repository for version 1.x has been renamed to "miniflux-legacy" causing installation to fail since "miniflux" now references the Go-based version 2.